### PR TITLE
fix: Importação do wait

### DIFF
--- a/Fork/ex4.c
+++ b/Fork/ex4.c
@@ -1,5 +1,6 @@
 #include<stdio.h>
 #include<unistd.h>
+#include<sys/wait.h>
 
 int main(void) {
         int variavel;


### PR DESCRIPTION
A execução do programa estava gerando o seguinte erro:
```
ex4.c: In function ‘main’:
ex4.c:11:17: warning: implicit declaration of function ‘wait’; did you mean ‘main’? [-Wimplicit-function-declaration]
                 wait(NULL);
                 ^~~~
                 main
```